### PR TITLE
[Bugfix] [Auth] Fix re-authentication

### DIFF
--- a/mobile_application/lib/pages/auth/widgets/auth_button.dart
+++ b/mobile_application/lib/pages/auth/widgets/auth_button.dart
@@ -1,4 +1,5 @@
 import 'package:mobile_application/pages/auth/auth_state.dart';
+import 'package:mobile_application/pages/home/home.dart';
 import 'package:mobile_application/pages/onboarding/onboarding.dart';
 import 'package:mobile_application/ui/theme.dart';
 import 'package:mobile_application/ui/widget/buttons/bus_button.dart';
@@ -20,32 +21,19 @@ class AuthButton extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.start,
           mainAxisSize: MainAxisSize.max,
           children: [
-            if (state.pageIndex != 0)
-              Padding(
-                  padding: const EdgeInsets.only(right: 8.0),
-                  child: CityCabButton(
-                    textColor: CityTheme.cityblue,
-                    color: CityTheme.cityLightGrey,
-                    title: 'Back',
-                    onTap: () {
-                      state.previousPage();
-                    },
-                  )),
-            if (state.pageIndex == 0)
-              Padding(
-                  padding: const EdgeInsets.only(right: 8.0),
-                  child: CityCabButton(
-                    textColor: CityTheme.cityblue,
-                    color: CityTheme.cityLightGrey,
-                    title: 'Back',
-                    onTap: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                            builder: (context) => const OnboardingPage()),
-                      );
-                    },
-                  )),
+            Padding(
+                padding: const EdgeInsets.only(right: 8.0),
+                child: CityCabButton(
+                  textColor: CityTheme.cityblue,
+                  color: CityTheme.cityLightGrey,
+                  title: 'Back',
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(builder: (context) => const HomePage()),
+                    );
+                  },
+                )),
             CityCabButton(
               textColor: Colors.white,
               color: state.phoneAuthState == PhoneAuthState.loading ||


### PR DESCRIPTION
**Problem:** When user clicked the `Back` button, the phone authentication does not work anymore
**Solution:** The phone authentication does not re-renders when the user clicked the `Back` button since it just returns to its previous page. Solution to the bug is to restart from the homepage so the phone authentication re-deploys.